### PR TITLE
Removed "--ignore-platform-reqs" and "--no-interaction" options from …

### DIFF
--- a/composer/1.3.0/Dockerfile
+++ b/composer/1.3.0/Dockerfile
@@ -20,4 +20,4 @@ RUN apk add --update curl \
     apk del curl && \
     rm -rf /var/cache/apk/*
 
-ENTRYPOINT ["/usr/local/bin/composer", "--ignore-platform-reqs", "--no-interaction"]
+ENTRYPOINT ["/usr/local/bin/composer"]

--- a/composer/1.3.0/README.md
+++ b/composer/1.3.0/README.md
@@ -12,7 +12,7 @@ Composer version: 1.0.0-beta1
 ## Usage
 
 ```
-$ docker run --rm -v /path/to/project/:/data imega/composer:1.3.0 install --no-dev
+$ docker run --rm -v /path/to/project/:/data imega/composer:1.3.0 install --no-dev --ignore-platform-reqs --no-interaction
 ```
 ## License
 

--- a/composer/CHANGELOG.md
+++ b/composer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.4.0
+-----
+
+ * Removed "--ignore-platform-reqs" and "--no-interaction" options from entrypoint
+
 1.3.0
 -----
 


### PR DESCRIPTION
…entrypoint
### Motivation for change

Hardcoded entrypoint options limits image usage as executable, as you constantly must rewrite the entrypoint, for example when issuing the init command.
