### PR TITLE
Removing unnecessary dependancy on bash

### DIFF
--- a/composer/2.1.1/Dockerfile
+++ b/composer/2.1.1/Dockerfile
@@ -6,7 +6,6 @@ ENV COMPOSER_CACHE_DIR=/cache
 
 RUN echo "@stale http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk add --update curl \
-        bash \
         git \
         php7@stale \
         php7-common@stale \
@@ -21,6 +20,9 @@ RUN echo "@stale http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/re
     ln -s /usr/bin/php7 /usr/bin/php && \
     curl -k -sS https://getcomposer.org/installer | php -- --version=1.0.0 --install-dir=/usr/local/bin --filename=composer && \
     apk del curl && \
+    printf '#!/bin/sh \n exec /bin/sh "$@"' > /bin/bash && \
+    chmod a+rx /bin/bash && \
+    /usr/bin/env bash -c 'echo BASH FORWARDER OK' && \
     rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["/usr/local/bin/composer"]


### PR DESCRIPTION
- Removed bash
- Added proper bash-to-sh forwarder
- Now has a test to verify the bash forwarder is okay.

Sorry for the previous broken version. This one tests itself.
