### PR TITLE
fix(mysql): Allow to create a temporal socket

### DIFF
--- a/mysql/1.1.0/Dockerfile
+++ b/mysql/1.1.0/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --update mysql && \
         echo 'datadir = /var/lib/mysql'; \
         echo 'port = 3306'; \
         echo 'log-bin = /var/lib/mysql/mysql-bin'; \
+        echo 'socket = /var/lib/mysql/mysql.sock'; \
         echo '!includedir /etc/mysql/conf.d/'; \
     } > /etc/mysql/my.cnf && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
When its created a new container the socket is created in the volume /var/lib/mysql/, this fix the future problems with host/other mysql connections.
